### PR TITLE
Add a list_retention_policies() method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ database = 'foo'
 influxdb.continuous_queries(database)
 ```
 
+List retention policies of a database:
+
+``` ruby
+database = 'foo'
+
+influxdb.list_retention_policies(database)
+```
+
 Write some data:
 
 ``` ruby

--- a/lib/influxdb.rb
+++ b/lib/influxdb.rb
@@ -16,6 +16,7 @@ require "influxdb/query/shard"
 require "influxdb/query/user"
 require "influxdb/query/continuous_query"
 require "influxdb/query/shard_space"
+require "influxdb/query/retention_policy"
 
 require "influxdb/client/http"
 require "influxdb/client"

--- a/lib/influxdb/client.rb
+++ b/lib/influxdb/client.rb
@@ -19,6 +19,7 @@ module InfluxDB
     include InfluxDB::Query::User
     include InfluxDB::Query::ContinuousQuery
     include InfluxDB::Query::ShardSpace
+    include InfluxDB::Query::RetentionPolicy
 
     # Initializes a new InfluxDB client
     #

--- a/lib/influxdb/query/retention_policy.rb
+++ b/lib/influxdb/query/retention_policy.rb
@@ -1,0 +1,17 @@
+module InfluxDB
+  module Query
+    module RetentionPolicy # :nodoc:
+      def list_retention_policies(database)
+        resp = execute("SHOW RETENTION POLICIES \"#{database}\"", parse: true)
+        data = fetch_series(resp).fetch(0)
+
+        data['values'].map do |policy|
+          entry = policy.each.with_index.inject({}) do |hash, (value, index)|
+            hash.tap { |h| h[data['columns'][index]] = value }
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/spec/influxdb/cases/query_retention_policy_spec.rb
+++ b/spec/influxdb/cases/query_retention_policy_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+require "json"
+
+describe InfluxDB::Client do
+  let(:subject) do
+    described_class.new(
+      "database",
+      {
+        host: "influxdb.test",
+        port: 9999,
+        username: "username",
+        password: "password",
+        time_precision: "s"
+      }.merge(args)
+    )
+  end
+
+  let(:args) { {} }
+
+  describe "#list_retention_policies" do
+    let(:response) { {"results"=>[{"series"=>[{"columns"=>["name","duration","replicaN","default"],"values"=>[["default","0",1,true],["another","1",2,false]]}]}]} }
+    let(:expected_result) { [{"name"=>"default","duration"=>"0","replicaN"=>1,"default"=>true},{"name"=>"another","duration"=>"1","replicaN"=>2,"default"=>false}] }
+
+    before do
+      stub_request(:get, "http://influxdb.test:9999/query").with(
+        query: {u: "username", p: "password", q: "SHOW RETENTION POLICIES \"database\""}
+      ).to_return(:body => JSON.generate(response), :status => 200)
+    end
+
+    it "should GET a list of retention policies" do
+      expect(subject.list_retention_policies('database')).to eq(expected_result)
+    end
+  end
+end


### PR DESCRIPTION
This adds a `list_retention_policies()` method.

I was torn between naming it `retention_policies` (similar to `continuous_queries`), or adding the `list_` prefix (which is consistent with `list_users`, `list_databases` etc) - I went with the latter.
